### PR TITLE
Added ->finalize to handler_psgi() result. Fixes Plack::Response.

### DIFF
--- a/lib/JSON/RPC/Dispatch.pm
+++ b/lib/JSON/RPC/Dispatch.pm
@@ -212,7 +212,7 @@ sub handle_psgi {
         $self->coder->encode( @$procedures > 1 ? \@response : $response[0] )
     );
 
-    return $res;
+    return $res->finalize;
 }
 
 no Try::Tiny;


### PR DESCRIPTION
hadnler_psgi() in JSON::RPC::Dispatch is not working with Plack (at least for version 0.9988).
Plack complains that the response should be array, not Plack::Response instance.
e.g.:
Response should be array ref or code ref: Plack::Response=HASH(0x1d1a928) at perl-lib/Plack/Middleware/Lint.pm line 101

handler_psgi() in Dispatcher.pm returns this:
return $res; # Plack::Response instance
instead of this:
return $res->finalize; # array

Please check and pull.
