### PR TITLE
add making additional error response data.

### DIFF
--- a/lib/JSON/RPC/Dispatch.pm
+++ b/lib/JSON/RPC/Dispatch.pm
@@ -196,13 +196,17 @@ sub handle_psgi {
             if (JSONRPC_DEBUG) {
                 warn "Error while executing $action: $e";
             }
+            my $error = {code => RPC_INTERNAL_ERROR} ;
+            if (ref $e eq "HASH") {
+               $error->{message} = $e->{message},
+               $error->{data}    = $e->{data},
+            } else {
+               $error->{message} = $e,
+            }
             push @response, {
                 jsonrpc => '2.0',
-                id => $procedure->id,
-                error => {
-                    code => RPC_INTERNAL_ERROR,
-                    message => $e,
-                }
+                id      => $procedure->id,
+                error   => $error,
             };
         };
     }

--- a/t/JSON/RPC/Test/Handler/Sum.pm
+++ b/t/JSON/RPC/Test/Handler/Sum.pm
@@ -17,4 +17,11 @@ sub sum {
     return $sum;
 }
 
+sub tidy_error {
+    die {
+        message => "short description of the error",
+        data    => "additional information about the error"
+    };
+}
+
 1;


### PR DESCRIPTION
Hi,                                                                                           

I want to making error object includes a message and data of the error member when some error occured in the dispatch.  
Because http://www.jsonrpc.org/specification 5.1 Error object defines the message should be limited to a concise single sentence.  
If long error message like a stacktrace, I want to assign value of the data member.
