### PR TITLE
Fix for call subroutine return

### DIFF
--- a/lib/JSON/RPC/Legacy/Client.pm
+++ b/lib/JSON/RPC/Legacy/Client.pm
@@ -107,19 +107,13 @@ sub call {
 
     $self->status_line($result->status_line);
 
-    if ($result->is_success) {
+    return unless($result->content); # notification?
 
-        return unless($result->content); # notification?
-
-        if ($service) {
-            return JSON::RPC::Legacy::ServiceObject->new($result, $self->json);
-        }
-
-        return JSON::RPC::Legacy::ReturnObject->new($result, $self->json);
+    if ($service) {
+        return JSON::RPC::Legacy::ServiceObject->new($result, $self->json);
     }
-    else {
-        return;
-    }
+
+    return JSON::RPC::Legacy::ReturnObject->new($result, $self->json);
 }
 
 


### PR DESCRIPTION
Removed check for "is_success" so that 400 and 500 http status codes are returned with error message from the http JSON-RPC server.

The "is_success" defined in HTTP::Status is >= 200 && < 300, so call would only return http status 2xx codes.
