### PR TITLE
Be consistent about newlines in error responses

### DIFF
--- a/lib/JSON/RPC/Dispatch.pm
+++ b/lib/JSON/RPC/Dispatch.pm
@@ -125,6 +125,7 @@ sub handle_psgi {
                 }
             };
         } else {
+            chomp $e;
             push @response, {
                 error => {
                     code => RPC_INVALID_REQUEST,


### PR DESCRIPTION
With `die()` you always get a newline character at the end of the error message, but that doesn't feel very idiomatic in JSON-RPC error messages.

This change chomps off that last newline character. If you really want a terminating newline you can still get it by calling `die "multi\nline\n\message\n\n";` and the chomp would only remove the very last one.