### PR TITLE
allow custom error code

### DIFF
--- a/lib/JSON/RPC/Dispatch.pm
+++ b/lib/JSON/RPC/Dispatch.pm
@@ -214,8 +214,9 @@ sub handle_psgi {
             if (!$is_notification) {
                 my $error = {code => RPC_INTERNAL_ERROR} ;
                 if (ref $e eq "HASH") {
-                   $error->{message} = $e->{message},
-                   $error->{data}    = $e->{data},
+                   $error->{message} = $e->{message};
+                   $error->{data}    = $e->{data} unless !defined $e->{data};
+                   $error->{code}    = $e->{code} unless !defined $e->{code};
                 } else {
                    $error->{message} = $e,
                 }

--- a/lib/JSON/RPC/Dispatch.pm
+++ b/lib/JSON/RPC/Dispatch.pm
@@ -215,8 +215,8 @@ sub handle_psgi {
                 my $error = {code => RPC_INTERNAL_ERROR} ;
                 if (ref $e eq "HASH") {
                    $error->{message} = $e->{message};
-                   $error->{data}    = $e->{data} unless !defined $e->{data};
-                   $error->{code}    = $e->{code} unless !defined $e->{code};
+                   $error->{data}    = $e->{data} if defined $e->{data};
+                   $error->{code}    = $e->{code} if defined $e->{code};
                 } else {
                    $error->{message} = $e,
                 }

--- a/t/JSON/RPC/Test/Handler/Sum.pm
+++ b/t/JSON/RPC/Test/Handler/Sum.pm
@@ -2,6 +2,11 @@ package t::JSON::RPC::Test::Handler::Sum;
 use strict;
 use Class::Accessor::Lite new => 1;
 
+use base 'Exporter';
+
+our @EXPORT_OK = qw( CUSTOM_ERROR_CODE );
+use constant CUSTOM_ERROR_CODE => -32000;
+
 sub blowup {
     die "I blew up!";
 }
@@ -21,6 +26,16 @@ sub tidy_error {
     die {
         message => "short description of the error",
         data    => "additional information about the error"
+    };
+}
+
+sub custom_error {
+    die {
+        code => CUSTOM_ERROR_CODE,
+        message => "short description of the error",
+        data    => {
+            some => 'data'
+        }
     };
 }
 


### PR DESCRIPTION
Allow setting custom error code (#7).

Throwing an error like this one:
```perl
die { code => -32000, data => { some => "data" }, message => "Internal error 012" };
```

results on the following json message:

```json
{
  "id": 1,
  "error": {
    "data": {
      "some": "data"
    },
    "code": -32000,
    "message": "Internal error 012"
  },
  "jsonrpc": "2.0"
}
```