### PR TITLE
[PATCH] JSON::RPC::Legacy::Client: Do not try to parse non-existing JSON

### DIFF
--- a/lib/JSON/RPC/Legacy/Client.pm
+++ b/lib/JSON/RPC/Legacy/Client.pm
@@ -107,6 +107,9 @@ sub call {
 
     $self->status_line($result->status_line);
 
+    # If the server returned an error, we have no JSON.
+    return if ($result->code >= 500 && $result->code < 600);
+
     return unless($result->content); # notification?
 
     if ($service) {


### PR DESCRIPTION

In Debian we are currently applying the following patch to JSON-RPC.
We thought you might be interested in it too.

    From fc84cb2df7ef9cbc33f6fc03975b3a96f34bb9ff Mon Sep 17 00:00:00 2001
    From: Guillem Jover <guillem@hadrons.org>
    Date: Sun, 21 Jul 2024 23:27:16 +0200
    Subject: [PATCH] JSON::RPC::Legacy::Client: Do not try to parse non-existing
     JSON
    
    If the server reported a server error, then we get no JSON. We should
    return immediately instead of trying to parse the non-existing JSON,
    otherwise the callers will get confusing and truncated errors.

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libjson-rpc-perl/raw/master/debian/patches/0001-JSON-RPC-Legacy-Client-Do-not-try-to-parse-non-exist.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
